### PR TITLE
Update electron-packager for multi-target build

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "start": "electron .",
-    "build": "electron-packager . $npm_package_productName --prune --asar --platform=darwin --arch=x64 --version=0.28.1"
+    "build": "electron-packager . $npm_package_productName --prune --asar --all --version=0.28.1"
   },
   "files": [
     "index.js",
@@ -30,7 +30,7 @@
     "electron-debug": "^0.1.0"
   },
   "devDependencies": {
-    "electron-packager": "^4.1.2",
+    "electron-packager": "^5.0.0",
     "electron-prebuilt": "^0.28.1"
   }
 }


### PR DESCRIPTION
`npm run-script build` will generate:
- linux ia32
- linux x64
- win32 ia32
- win32 x64
- darwin x64

by option `--all` 
