### PR TITLE
Use a less common build output folder name to avoid ignore collisions

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "start": "electron .",
-    "build": "electron-packager . $npm_package_productName --out=dist --ignore=dist --prune --asar --all --version=0.30.0"
+    "build": "electron-packager . $npm_package_productName --out=$npm_package_productName-dist --ignore=$npm_package_productName-dist --prune --asar --all --version=0.30.0"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
I don't really like this solution, but it fixes the problem in #16. I think the ideal solution would be to ignore only `./dist` from the current working directory, but I couldn't get that to work.

Fixes #16 
