### PR TITLE
Remove unnecessary `"esnext": true`

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -34,7 +34,6 @@
     "xo": "^0.16.0"
   },
   "xo": {
-    "esnext": true,
     "envs": [
       "node",
       "browser"


### PR DESCRIPTION
Deleted the `esnext` option in the xo configuration in the `_package.json` template file, since it’s true by default, as stated in [the readme of xo](https://github.com/sindresorhus/xo#esnext).